### PR TITLE
Set default for LastNotifiedDate to empty string

### DIFF
--- a/code/client/munkilib/munkicommon.py
+++ b/code/client/munkilib/munkicommon.py
@@ -1203,7 +1203,7 @@ def pref(pref_name):
         'AppleSoftwareUpdatesOnly': False,
         'SoftwareUpdateServerURL': '',
         'DaysBetweenNotifications': 1,
-        'LastNotifiedDate': NSDate.dateWithTimeIntervalSince1970_(0),
+        'LastNotifiedDate': '',
         'UseClientCertificate': False,
         'SuppressUserNotification': False,
         'SuppressAutoInstall': False,


### PR DESCRIPTION
https://github.com/oliof/munki/blob/master/code/client/managedsoftwareupdate#L407 checks for the boolean value of lastNotifiedString. In the original version, the result would be "1970-01-01 +00:00:00" which always resolved to True in this check, making everything in lines 408 and below effectively dead code. Returning an empty string by default retains type behavior of LastNotifiedString and fixes this boolean check.
